### PR TITLE
Fix possible fix(deps): 17 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,61 +3,61 @@ module yyb_go
 go 1.23.0
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	github.com/go-sql-driver/mysql v1.9.3
-	github.com/swaggo/http-swagger/v2 v2.0.2
-	golang.org/x/crypto v0.39.0
-	modernc.org/sqlite v1.38.2
+    github.com/gin-gonic/gin v1.10.1
+    github.com/go-sql-driver/mysql v1.9.3
+    github.com/swaggo/http-swagger/v2 v2.0.2
+    golang.org/x/crypto v0.55.0
+    modernc.org/sqlite v1.38.2
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/KyleBanks/depth v1.2.1 // indirect
-	github.com/bytedance/sonic v1.11.6 // indirect
-	github.com/bytedance/sonic/loader v0.1.1 // indirect
-	github.com/cloudwego/base64x v0.1.4 // indirect
-	github.com/cloudwego/iasm v0.2.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.20.0 // indirect
-	github.com/go-openapi/spec v0.20.6 // indirect
-	github.com/go-openapi/swag v0.19.15 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.20.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
-	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
-	github.com/swaggo/files/v2 v2.0.0 // indirect
-	github.com/swaggo/swag v1.8.1 // indirect
-	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/ugorji/go/codec v1.2.12 // indirect
-	golang.org/x/arch v0.8.0 // indirect
-	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.41.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
-	golang.org/x/text v0.26.0 // indirect
-	golang.org/x/tools v0.34.0 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	modernc.org/libc v1.66.3 // indirect
-	modernc.org/mathutil v1.7.1 // indirect
-	modernc.org/memory v1.11.0 // indirect
+    filippo.io/edwards25519 v1.1.0 // indirect
+    github.com/KyleBanks/depth v1.2.1 // indirect
+    github.com/bytedance/sonic v1.11.6 // indirect
+    github.com/bytedance/sonic/loader v0.1.1 // indirect
+    github.com/cloudwego/base64x v0.1.4 // indirect
+    github.com/cloudwego/iasm v0.2.0 // indirect
+    github.com/dustin/go-humanize v1.0.1 // indirect
+    github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+    github.com/gin-contrib/sse v0.1.0 // indirect
+    github.com/go-openapi/jsonpointer v0.19.5 // indirect
+    github.com/go-openapi/jsonreference v0.20.0 // indirect
+    github.com/go-openapi/spec v0.20.6 // indirect
+    github.com/go-openapi/swag v0.19.15 // indirect
+    github.com/go-playground/locales v0.14.1 // indirect
+    github.com/go-playground/universal-translator v0.18.1 // indirect
+    github.com/go-playground/validator/v10 v10.20.0 // indirect
+    github.com/goccy/go-json v0.10.2 // indirect
+    github.com/google/uuid v1.6.0 // indirect
+    github.com/josharian/intern v1.0.0 // indirect
+    github.com/json-iterator/go v1.1.12 // indirect
+    github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+    github.com/kr/pretty v0.3.1 // indirect
+    github.com/leodido/go-urn v1.4.0 // indirect
+    github.com/mailru/easyjson v0.7.6 // indirect
+    github.com/mattn/go-isatty v0.0.20 // indirect
+    github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+    github.com/modern-go/reflect2 v1.0.2 // indirect
+    github.com/ncruces/go-strftime v0.1.9 // indirect
+    github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+    github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+    github.com/rogpeppe/go-internal v1.10.0 // indirect
+    github.com/stretchr/testify v1.11.1 // indirect
+    github.com/swaggo/files/v2 v2.0.0 // indirect
+    github.com/swaggo/swag v1.8.1 // indirect
+    github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+    github.com/ugorji/go/codec v1.2.12 // indirect
+    golang.org/x/arch v0.8.0 // indirect
+    golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
+    golang.org/x/net v0.56.0 // indirect
+    golang.org/x/sys v0.34.0 // indirect
+    golang.org/x/text v0.39.0 // indirect
+    golang.org/x/tools v0.34.0 // indirect
+    google.golang.org/protobuf v1.34.1 // indirect
+    gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+    gopkg.in/yaml.v2 v2.4.0 // indirect
+    gopkg.in/yaml.v3 v3.0.1 // indirect
+    modernc.org/libc v1.66.3 // indirect
+    modernc.org/mathutil v1.7.1 // indirect
+    modernc.org/memory v1.11.0 // indirect
 )


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

CRITICAL risk - Authorization bypass (CVE-2026-56854) in golang.org/x/crypto (SSH server package). The 'source-address' critical option set in Permissions returned by SSH authentication callbacks was only enforced on the public-key authentication paths (PublicKeyCallback, VerifiedPublicKeyCallback). For PasswordCallback, KeyboardInteractiveCallback, NoClientAuthCallback, and GSSAPIWithMICConfig.AllowLogin, any source-address restriction the server returned was silently ignored. Impact: an SSH server that relies on source-address restrictions (e.g., IP allowlists or network-segment-based access control) configured via these callbacks can be accessed by attackers from unauthorized/disallowed source IPs, leading to unauthorized access or privilege escalation when combined with valid credentials. The project uses v0.39.0, which is vulnerable; the fix is available in v0.55.0. Recommended remediation: upgrade golang.org/x/crypto to v0.55.0 or later (this extends the earlier CVE-2026-46595 fix so source-address checks apply to Permissions from ALL authentication callbacks). If an immediate upgrade is not possible, as an interim mitigation manually validate conn.RemoteAddr() against your allowlist inside each callback before returning Permissions.

Update vulnerable dependencies to versions that fix known CVEs: golang.org/x/crypto, golang.org/x/net, and golang.org/x/text.

For reference: rule `CVE-2026-56854`. Rated critical.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
